### PR TITLE
Additional tests and log removal

### DIFF
--- a/test/spec.js
+++ b/test/spec.js
@@ -432,42 +432,6 @@ test('it should not return any Entity given an invalid ID', function(t) {
   .expect(404, pass(t, 'returned 404 not found'));
 });
 
-// test('it should allow metadata properties to be posted and returned', function(t) {
-//   const one = genEntity();
-
-//   request(server)
-//   .post('/entities')
-//   .auth('test', key)
-//   .send(one)
-//   .expect(200)
-//   .end((err, oneRes) => {
-//     const perms = {
-//       type: 'bar',
-//       entity: oneRes.body.id,
-//       metadata: {
-//         type: "little creatures"
-//       }
-//     };
-
-//     const two = genEntity();
-//     two.permissions = [perms];
-
-//     request(server)
-//     .post('/entities')
-//     .auth('test', key)
-//     .send(two)
-//     .end((err, twoRes) => {
-//       request(server)
-//       .get('/entities/' + twoRes.body.id)
-//       .auth('test', key)
-//       .expect(res => {
-//         res.body.permissions[0].metadata.type = 'little creatures'
-//       })
-//       .expect(200, pass(t, 'returned correct entity'))
-//     })
-//   })
-// });
-
 test('it should allow metadata to be posted in a permission', function(t) {
   const entity = genEntity();
   entity.permissions = [{


### PR DESCRIPTION
This branch:
- Splits the metadata data into three separate tests as per Dave's comments.
- Removes accidental console.log()

(May need some guidance re: the inheritance test if assertion is not correct)